### PR TITLE
276: Make helm values common to those used by iam initialiser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pact/
 temp
 config/viper/*
 !viper-default-configuration.yaml
+BohoDockerfile

--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob-secret.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob-secret.yaml
@@ -1,9 +1,9 @@
-{{- if eq .Values.environment.type "FIDC" }}
+{{- if eq .Values.environment.fr_platform.type "FIDC" }}
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: initializer-secret
-  namespace: {{ .Values.environment.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   backendType: gcpSecretsManager
   projectId: {{ .Values.projectId }}

--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: test-init
+  name: test-data-init
 spec:
   schedule: "{{ .Values.cron }}"
   concurrencyPolicy: Forbid
@@ -13,13 +13,16 @@ spec:
         spec:
           containers:
             - name: test-init
-              image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-test-data-initializer:latest
+              image: {{ tpl .Values.test_data_initializer_image_location . }}
               imagePullPolicy: Always
               env:
                 - name: ENVIRONMENT.STRICT
                   value: {{ .Values.environment.strict | quote }}
                 - name: ENVIRONMENT.TYPE
-                  value: {{ .Values.environment.type }}
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: ENVIRONMENT_TYPE
                 - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
                   valueFrom:
                     configMapKeyRef:
@@ -35,7 +38,7 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: RS_FQDN
-                {{- if eq .Values.environment.type "FIDC" }}
+                {{- if eq .Values.environment.fr_platform.type "FIDC" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -48,7 +51,10 @@ spec:
                       key: cdm-admin-user
                 {{- else }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
-                  value: {{ .Values.environment.frPlatformAdminPassword }}                  
+                  valueFrom:
+                    secretKeyRef:
+                      name: am-env-secrets
+                      key: AM_PASSWORDS_AMADMIN_CLEAR
                 {{ end }}              
                 - name: NAMESPACE
                   value: {{ .Values.environment.namespace }}

--- a/_infra/helm/securebanking-test-data-initializer/values.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/values.yaml
@@ -1,17 +1,37 @@
 cron: "* * * * *"
 
+# ** Value Name:** iam_initializer_image_location
+#
+# ** Value Description** 
+# Location of the image in your docker repository. Override this in your own values file.
+# The template expects a tpl value, which enables the image location to be built up from
+# values containing repo location, image name etc. e.g.
+# 
+#  # Values from file
+#  helm_repository: eu.gcr.io/sbat-gcr-develop/securebanking
+#  test_data_initializer_image_name: secureopenbanking-uk-test-initializer
+#  test_data_initializer_image_tag: latest
+#  test_data_initializer_image_location: "{{ .Values.helm_repository }}/{{ .Values.test_data_initializer_image_name }}:{{ .Values.test_data_initializer_image_tag}}"
+
 # environment.type: It can be:
 # CDK value: (Cloud Developer's Kit) development identity platform
 # CDM value: CDM (Cloud Deployment Model) identity cloud platform
 # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
 environment:
-  type: FIDC
-  namespace: dev
+  # Configuration relating to the FR Platform
+  fr_platform:
+    type: FIDC
+    fqdn: iam.dev.forgerock.financial
+  # Configuration relation to the SBAT deployment
+  sbat:
+    # The GCP project in which the SBAT is deployed
+    projectId: sbat-dev
+    fqdn: dev.forgerock.financial
+
   # RaiseForStatus will exit if go resty returns an error in STRICT mode,
   # be it client error, server error or other. Turning off (false)
   # STRICT mode will simply warn of client/server errors.
   strict: true
   frPlatformAdminPassword: replace
 
-# The GCP project where the secret lives
-projectId: sbat-dev
+  namespace: dev

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -11,6 +11,7 @@ ENVIRONMENT: # Root key to define the environment program properties
   # CDM value: CDM (Cloud Deployment Model) identity cloud platform
   # FIDC (Forgerock Identity Cloud) identity cloud platform
   TYPE: CDK
+  NAMESPACE: dev # Root key to get the namespace/environment to populate the user data
 HOSTS:
   RS_FQDN: rs.dev.forgerock.financial # RS host name
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial # Identity platform Host name
@@ -22,4 +23,3 @@ USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)
   PSU_USERNAME: psu4test # Psu Username to (It will be created)
   PSU_PASSWORD: 0penBanking! # Psu user password (It will be created)
-NAMESPACE: dev # Root key to get the namespace/environment to populate the user data

--- a/main.go
+++ b/main.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 	"os"
 	"securebanking-test-data-initializer/pkg/common"
 	"securebanking-test-data-initializer/pkg/httprest"
 	platform "securebanking-test-data-initializer/pkg/identity-platform"
 	"securebanking-test-data-initializer/pkg/rs"
 	"securebanking-test-data-initializer/pkg/types"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
 )
 
 // init function is execute before main to initialize the program,
@@ -85,6 +86,7 @@ func loadConfiguration() {
 		zap.S().Fatalw("Cannot load config:", "error", err)
 	}
 	config = common.Config
+	zap.S().Info("Config is: %s", types.ToStr(config))
 }
 
 func checks() {
@@ -92,9 +94,9 @@ func checks() {
 }
 
 func getIdentityPlatformSession() *common.Session {
-	zap.L().Info("Get CookieName")
+	zap.L().Info("getIdentityPlatformSession() Get CookieName")
 	c := platform.GetCookieNameFromAm()
-	zap.L().Info("Get user session")
+	zap.L().Info("getIdentityPlatformSession() Get user session")
 	return platform.FromUserSession(c)
 }
 

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -1,5 +1,11 @@
 package types
 
+import "fmt"
+
+func ToStr(config Configuration) string {
+	return fmt.Sprintf("Config is %#v", config)
+}
+
 type Configuration struct {
 	Environment environment `mapstructure:"ENVIRONMENT"`
 	Identity    identity    `mapstructure:"IDENTITY"`


### PR DESCRIPTION
Create some commonality across the iam and test-data initialiser

Making values consistent across initializers. Aligning helm, viper and
docker env variable names.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/276