### PR TITLE
304: Fix authentication with FIDC environment

### DIFF
--- a/config/defaults/auth-helper/FidcDismiss2FA.json
+++ b/config/defaults/auth-helper/FidcDismiss2FA.json
@@ -1,0 +1,98 @@
+{
+  "authId": "{{authId}}",
+  "callbacks": [
+    {
+      "type": "TextOutputCallback",
+      "output": [
+        {
+          "name": "message",
+          "value": "message-761"
+        },
+        {
+          "name": "messageType",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "ConfirmationCallback",
+      "output": [
+        {
+          "name": "prompt",
+          "value": ""
+        },
+        {
+          "name": "messageType",
+          "value": 0
+        },
+        {
+          "name": "options",
+          "value": [
+            "Set up"
+          ]
+        },
+        {
+          "name": "optionType",
+          "value": -1
+        },
+        {
+          "name": "defaultOption",
+          "value": 0
+        }
+      ],
+      "input": [
+        {
+          "name": "IDToken2",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "HiddenValueCallback",
+      "output": [
+        {
+          "name": "value",
+          "value": "false"
+        },
+        {
+          "name": "id",
+          "value": "skip-input-761"
+        }
+      ],
+      "input": [
+        {
+          "name": "IDToken3",
+          "value": "Skip"
+        }
+      ]
+    },
+    {
+      "type": "TextOutputCallback",
+      "output": [
+        {
+          "name": "message",
+          "value": "var skipContainer = document.createElement(\"div\");skipContainer.style = \"width:100%\";skipContainer.innerHTML = \"<button id='skip-link-761' class='btn btn-block btn-link' type='submit'>Skip for now</button>\";document.getElementById(\"skip-input-761\").parentNode.append(skipContainer);document.getElementsByClassName(\"callback-component\").forEach(  function (e) {    var message = e.firstElementChild;    if (message.firstChild && message.firstChild.nodeName == \"#text\" && message.firstChild.nodeValue.trim() == \"message-761\") {      message.align = \"center\";      message.innerHTML = \"<h2 class='h2'>Set up 2-step verification</h2><div style='margin-bottom:1em'>Protect your account by adding a second step after entering your password to verify it's you signing in.</div>\";    }  })"
+        },
+        {
+          "name": "messageType",
+          "value": "4"
+        }
+      ]
+    },
+    {
+      "type": "TextOutputCallback",
+      "output": [
+        {
+          "name": "message",
+          "value": "document.getElementById(\"skip-link-761\").onclick = function() {  document.getElementById(\"skip-input-761\").value = \"Skip\";  document.getElementById(\"loginButton_0\").click();  return false;}"
+        },
+        {
+          "name": "messageType",
+          "value": "4"
+        }
+      ]
+    }
+  ],
+  "status": 200,
+  "ok": true
+}

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -12,6 +12,8 @@ ENVIRONMENT: # Root key to define the environment program properties
   # FIDC (Forgerock Identity Cloud) identity cloud platform
   TYPE: CDK
   NAMESPACE: dev # Root key to get the namespace/environment to populate the user data
+  PATHS:
+    CONFIG_AUTH_HELPER: config/defaults/auth-helper/  # Path for json to help with auth on FIdC platform
 HOSTS:
   RS_FQDN: rs.dev.forgerock.financial # RS host name
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial # Identity platform Host name

--- a/pkg/identity-platform/authenticate.go
+++ b/pkg/identity-platform/authenticate.go
@@ -1,12 +1,14 @@
 package platform
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/go-resty/resty/v2"
+	"go.uber.org/zap"
+	"io/ioutil"
 	"net/http"
 	"securebanking-test-data-initializer/pkg/common"
 	"securebanking-test-data-initializer/pkg/types"
-
-	"go.uber.org/zap"
 )
 
 func GetCookieNameFromAm() string {
@@ -33,7 +35,13 @@ func GetCookieNameFromAm() string {
 func FromUserSession(cookieName string) *common.Session {
 	zap.L().Info("Getting an admin session from Identity Platform")
 
-	path := fmt.Sprintf("https://%s/am/json/realms/root/authenticate?authIndexType=service&authIndexValue=ldapService", common.Config.Hosts.IdentityPlatformFQDN)
+	path := ""
+	platformType := common.Config.Environment.Type
+	if platformType == "FIDC" {
+		path = fmt.Sprintf("https://%s/am/json/realms/root/authenticate", common.Config.Hosts.IdentityPlatformFQDN)
+	} else {
+		path = fmt.Sprintf("https://%s/am/json/realms/root/authenticate?authIndexType=service&authIndexValue=ldapService", common.Config.Hosts.IdentityPlatformFQDN)
+	}
 
 	zap.S().Infow("Path to authenticate the user", "path", path)
 
@@ -45,14 +53,23 @@ func FromUserSession(cookieName string) *common.Session {
 		Post(path)
 
 	common.RaiseForStatus(err, resp.Error(), resp.StatusCode())
+	zap.S().Infof("Got response code %v from %v", resp.StatusCode(), path)
+
+	if platformType == "FIDC" {
+		resp, err = dismiss2faDialog(path, resp)
+		if err != nil {
+			zap.S().Fatalw("Failed to dimiss 2FA as part of FIDC auth flow", "error", err)
+		}
+	}
 
 	var cookieValue = ""
 	for _, cookie := range resp.Cookies() {
-		zap.S().Infow("Cookie found", "cookie", cookie)
+		zap.S().Infow("Cookies found", "cookie", cookie)
 		if cookie.Name == cookieName {
 			cookieValue = cookie.Value
 		}
 	}
+
 	if cookieValue == "" {
 		zap.S().Fatalw("Cannot find cookie",
 			"statusCode", resp.StatusCode(),
@@ -61,6 +78,7 @@ func FromUserSession(cookieName string) *common.Session {
 				 AM will not react well to successive session requests`,
 			"error", resp.Error())
 	}
+
 	c := &http.Cookie{
 		Name:     cookieName,
 		Value:    cookieValue,
@@ -69,8 +87,48 @@ func FromUserSession(cookieName string) *common.Session {
 		Secure:   true,
 		Domain:   common.Config.Hosts.IdentityPlatformFQDN,
 	}
+
 	s := &common.Session{}
 	s.Cookie = c
 	zap.S().Infow("New Identity Platform session created", "cookie", s.Cookie)
 	return s
+}
+
+func dismiss2faDialog(requestUri string, resp *resty.Response) (*resty.Response, error) {
+	bodyString := string(resp.Body()[:])
+	zap.S().Infof("Dismissing 2FA dialog as authing to FIDC. Auth response body is %v", bodyString)
+
+	var responseJson map[string]interface{}
+	json.Unmarshal(resp.Body(), &responseJson)
+	authId := responseJson["authId"]
+	zap.S().Infof("authId to use in 2FA request: %v", authId)
+
+	cookies := resp.Cookies()
+
+	requestTemplate, erro := ioutil.ReadFile(common.Config.Environment.Paths.ConfigAuthHelper + "FidcDismiss2FA.json")
+	if erro != nil {
+		return nil, erro
+	}
+	var requestJson map[string]interface{}
+	json.Unmarshal(requestTemplate, &requestJson)
+	requestJson["authId"] = authId
+	zap.S().Infow("Request json used to dismiss 2FA", "requestJson", requestJson)
+
+	resp, err := restClient.R().
+		SetHeader("Accept", "application/json").
+		SetHeader("Accept-API-Version", "resource=2.1, protocol=1.0").
+		SetHeader("Content-Type", "application/json").
+		SetCookies(cookies).
+		SetBody(requestJson).
+		Post(requestUri)
+
+	if err != nil {
+		zap.S().Warnf("Failed to dismiss 2FA. ErrorCode %v", resp.StatusCode())
+		return nil, err
+	} else {
+		var jsonMap map[string]interface{}
+		json.Unmarshal(resp.Body(), &jsonMap)
+		zap.S().Infof("Dismissed 2FA - statusCode: %v,  %v", resp.StatusCode(), jsonMap)
+		return resp, nil
+	}
 }

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -28,6 +28,7 @@ type environment struct {
 	Verbose bool   `mapstructure:"VERBOSE"`
 	Strict  bool   `mapstructure:"STRICT"`
 	Type    string `mapstructure:"TYPE"`
+	Paths   paths  `mapstructure:"PATHS"`
 }
 
 type users struct {
@@ -35,4 +36,8 @@ type users struct {
 	FrPlatformAdminPassword string `mapstructure:"FR_PLATFORM_ADMIN_PASSWORD"`
 	PsuUsername             string `mapstructure:"PSU_USERNAME"`
 	PsuPassword             string `mapstructure:"PSU_PASSWORD"`
+}
+
+type paths struct {
+	ConfigAuthHelper string `mapstructure:"CONFIG_AUTH_HELPER"`
 }


### PR DESCRIPTION
Adding logic to dismiss the 2FA popup which occurs during FIDC authenticaiton

This code has been copied from the iam-initializer, an issue has been raised to create a go module to handle common functionality such as authentication: https://github.com/SecureApiGateway/SecureApiGateway/issues/711

https://github.com/SecureApiGateway/SecureApiGateway/issues/304