### PR TITLE
743: Creates the user for test purposes with a specific ID

### DIFF
--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -23,5 +23,6 @@ IDENTITY: # Root key for parameter values related with identity platform configu
 USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_USERNAME: amadmin # Identity platform Username with admin grants (must exist previously)
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)
+  PSU_USER_ID: 4737f9f9-fa0a-4159-bc61-7da31542e624 # Psu User Id to (It will be created): needs to be a UUID
   PSU_USERNAME: psu4test # Psu Username to (It will be created)
   PSU_PASSWORD: 0penBanking! # Psu user password (It will be created)

--- a/pkg/rs/psu_account.go
+++ b/pkg/rs/psu_account.go
@@ -2,14 +2,13 @@ package rs
 
 import (
 	"encoding/json"
+	"go.uber.org/zap"
 	"net/http"
 	"net/url"
 	"securebanking-test-data-initializer/pkg/common"
 	"securebanking-test-data-initializer/pkg/httprest"
 	"securebanking-test-data-initializer/pkg/types"
 	"strconv"
-
-	"go.uber.org/zap"
 )
 
 // CreatePSU - create the psu user if necessary and always return the userId if exist to populate de user data into RS
@@ -23,6 +22,7 @@ func CreatePSU() string {
 	zap.L().Info("Creating PSU (Payment Services User)")
 
 	user := &PSU{
+		UserId:    common.Config.Users.PsuUserId,
 		UserName:  common.Config.Users.PsuUsername,
 		SN:        "Payment Services User",
 		GivenName: "PSU",
@@ -83,7 +83,7 @@ func PopulateRSData(userId string) {
 	path := common.Config.Hosts.Scheme + "://" + common.Config.Hosts.RsFQDN + "/admin/data/user/has-data?userId=" + userId
 	if mustPopulateUserData(path) {
 		zap.S().Infow("Populate with RS Data the Payment Services User with the userId: " + userId)
-		params := "userId=" + userId + "&username=" + userId + "&profile=random"
+		params := "userId=" + userId + "&username=" + common.Config.Users.PsuUsername + "&profile=random"
 		path := common.Config.Hosts.Scheme + "://" + common.Config.Hosts.RsFQDN + "/admin/fake-data/generate?" + params
 		s := httprest.Client.PostRS(path, map[string]string{
 			"Accept":     "*/*",
@@ -93,7 +93,6 @@ func PopulateRSData(userId string) {
 	}
 	//}
 }
-
 
 // mustPopulateUserData check if the user has data and if the environment is initialised, return true/false
 func mustPopulateUserData(path string) bool {

--- a/pkg/rs/psu_models.go
+++ b/pkg/rs/psu_models.go
@@ -1,6 +1,7 @@
 package rs
 
 type PSU struct {
+	UserId    string `json:"_id"`
 	UserName  string `json:"userName"`
 	SN        string `json:"sn"`
 	GivenName string `json:"givenName"`

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -34,6 +34,7 @@ type environment struct {
 type users struct {
 	FrPlatformAdminUsername string `mapstructure:"FR_PLATFORM_ADMIN_USERNAME"`
 	FrPlatformAdminPassword string `mapstructure:"FR_PLATFORM_ADMIN_PASSWORD"`
+	PsuUserId               string `mapstructure:"PSU_USER_ID"`
 	PsuUsername             string `mapstructure:"PSU_USERNAME"`
 	PsuPassword             string `mapstructure:"PSU_PASSWORD"`
 }


### PR DESCRIPTION
- Added support to configure the psu user id
- Added support to populate the user id provided in the configuration when the user is created in the cloud platform
- Fix the username value parameter                                   when the initialiser request to populate the user data to RS
Issue: https://github.com/secureapigateway/secureapigateway/issues/743