### PR TITLE
818: Replacing RS_FQDN configuration with RS_BASE_URI

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -37,11 +37,6 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: IDENTITY_PLATFORM_FQDN
-                - name: HOSTS.RS_FQDN
-                  valueFrom:
-                    configMapKeyRef:
-                      name: securebanking-platform-config
-                      key: RS_FQDN
                 {{- if eq .Values.environment.fr_platform.type "FIDC" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -15,7 +15,7 @@ ENVIRONMENT: # Root key to define the environment program properties
   PATHS:
     CONFIG_AUTH_HELPER: config/defaults/auth-helper/  # Path for json to help with auth on FIdC platform
 HOSTS:
-  RS_FQDN: rs.dev.forgerock.financial # RS host name
+  RS_BASE_URI: http://securebanking-openbanking-uk-rs:8080 # Base URI for RS API
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial # Identity platform Host name
   SCHEME: https # URI scheme, Syntax part of a generic URI
 IDENTITY: # Root key for parameter values related with identity platform configuration

--- a/pkg/rs/psu_account.go
+++ b/pkg/rs/psu_account.go
@@ -80,11 +80,11 @@ func PopulateRSData(userId string) {
 		return
 	}
 
-	path := common.Config.Hosts.Scheme + "://" + common.Config.Hosts.RsFQDN + "/admin/data/user/has-data?userId=" + userId
+	path := common.Config.Hosts.RsBaseUri + "/admin/data/user/has-data?userId=" + userId
 	if mustPopulateUserData(path) {
 		zap.S().Infow("Populate with RS Data the Payment Services User with the userId: " + userId)
 		params := "userId=" + userId + "&username=" + common.Config.Users.PsuUsername + "&profile=random"
-		path := common.Config.Hosts.Scheme + "://" + common.Config.Hosts.RsFQDN + "/admin/fake-data/generate?" + params
+		path := common.Config.Hosts.RsBaseUri + "/admin/fake-data/generate?" + params
 		s := httprest.Client.PostRS(path, map[string]string{
 			"Accept":     "*/*",
 			"Connection": "keep-alive",

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -15,7 +15,7 @@ type Configuration struct {
 }
 
 type hosts struct {
-	RsFQDN               string `mapstructure:"RS_FQDN"`
+	RsBaseUri            string `mapstructure:"RS_BASE_URI"`
 	IdentityPlatformFQDN string `mapstructure:"IDENTITY_PLATFORM_FQDN"`
 	Scheme               string `mapstructure:"SCHEME"`
 }


### PR DESCRIPTION
Configuring RS_BASE_URI to use the internal k8s service address.

https://github.com/SecureApiGateway/SecureApiGateway/issues/818