### PR TITLE
906 - Add in yaml manifest for running test initialiser as a job

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -3,6 +3,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: test-data-init
+  annotations:
+    "helm.sh/hook": post-install
 spec:
   template:
     spec:


### PR DESCRIPTION
Change the job to run post install, this makes sure that the RS pod is up and running as the test initialiser relies on communicating with RS

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/906