### PR TITLE
987: Artifact Registry Migration

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,8 +11,8 @@ env:
   GIT_SHA_SHORT: $(echo ${{ github.sha }} | cut -c1-7)
 
 jobs:
-  build:
-    name: Build
+  check:
+    name: Check Changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,19 +21,27 @@ jobs:
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v0
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
-          gcloud auth configure-docker
+      - name: Auth Docker
+        run: |
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: docker build
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,33 +11,47 @@ env:
   PR_NUMBER: pr-${{ github.event.number }}
 
 jobs:
-  build:
-    name: Build
+  check:
+    name: Check Changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
+      
       - name: Run Tests
         run: |
           make test-ci
 
-      - uses: google-github-actions/auth@v0
+  build:
+    name: Build Image
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
-          gcloud auth configure-docker
+      - name: Auth Docker
+        run: |
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: docker build
         run: |
           make docker tag=${{ env.PR_NUMBER }}
 
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      
       - name: Create lowercase Github Username
-        id: toLowerCase
         run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
 
       - name: 'Deploy Service'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
       SERVICE_NAME: securebanking-test-data-initializer
       with_maven: false # skip set java and maven configuration
     secrets:
-      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
-      GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
+      GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
+      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_helm:
     name: Call publish helm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name := securebanking-test-data-initializer
-repo := sbat-gcr-develop
+repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 helm_repo := forgerock-helm/secure-api-gateway/securebanking-test-data-initializer/
 
 .PHONY: all
@@ -28,8 +28,8 @@ ifndef tag
 	$(eval tag=latest)
 endif
 	env GOOS=linux GOARCH=amd64 go build -o initialize
-	docker buildx build --platform linux/amd64 -t eu.gcr.io/${repo}/securebanking/${name}:${tag} .
-	docker push eu.gcr.io/${repo}/securebanking/${name}:${tag}
+	docker buildx build --platform linux/amd64 -t ${repo}/securebanking/${name}:${tag} .
+	docker push ${repo}/securebanking/${name}:${tag}
 
 package_helm:
 ifndef version

--- a/quick-deployment4tests.md
+++ b/quick-deployment4tests.md
@@ -1,14 +1,14 @@
 ## How tests the changes
 1. `make docker`
 2. ```shell
-   docker tag eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-test-data-initializer:latest eu.gcr.io/sbat-gcr-release/securebanking/securebanking-test-data-initializer:latest
+   docker tag europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-test-data-initializer:latest europe-west4-docker.pkg.dev/sbat-gcr-release/sapig-docker-artifact/securebanking/securebanking-test-data-initializer:latest
    ```
 3. ```shell
    docker push !$[+TAB]
    ```
    Or
    ```shell
-   docker push eu.gcr.io/sbat-gcr-release/securebanking/securebanking-test-data-initializer:latest
+   docker push europe-west4-docker.pkg.dev/sbat-gcr-release/sapig-docker-artifact/securebanking/securebanking-test-data-initializer:latest
    ```
 4. Change kubernetes context to `sbat-master-dev`
 5. Set the namespace to the developer namespace


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202