### PR TITLE
1315: Remove unwanted config from dev-core

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -39,13 +39,24 @@ spec:
                     configMapKeyRef:
                       name: core-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
-                {{- if ne .Values.cronjob.environment.frPlatformType "FIDC" }}
+                {{- if eq .Values.job.environment.frPlatformType "FIDC" }}
+                - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: initializer-secret
+                      key: cdm-admin-password
+                - name: USERS.FR_PLATFORM_ADMIN_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: initializer-secret
+                      key: cdm-admin-user
+                {{- else }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: am-env-secrets
-                      key: AM_PASSWORDS_AMADMIN_CLEAR
-                {{ end }}              
+                      key: AM_PASSWORDS_AMADMIN_CLEAR      
+                {{ end }}            
                 - name: NAMESPACE
                   value: {{ .Values.cronjob.namespace }}
               command: [ "/bin/sh", "-c" ]

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -33,13 +33,24 @@ spec:
                 configMapKeyRef:
                   name: core-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
-            {{- if ne .Values.job.environment.frPlatformType "FIDC" }}
+            {{- if eq .Values.job.environment.frPlatformType "FIDC" }}
+            - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: initializer-secret
+                  key: cdm-admin-password
+            - name: USERS.FR_PLATFORM_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: initializer-secret
+                  key: cdm-admin-user
+            {{- else }}
             - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: am-env-secrets
-                  key: AM_PASSWORDS_AMADMIN_CLEAR
-            {{ end }}              
+                  key: AM_PASSWORDS_AMADMIN_CLEAR      
+            {{ end }}    
             - name: NAMESPACE
               value: {{ .Values.job.namespace }}
           command: [ "/bin/sh", "-c" ]


### PR DESCRIPTION
Revert removal of initialiser secret, as fidc configuratior is not ready to use service accounts yet

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315