### PR TITLE
1337: Run functions in test user based on CLOUD_TYPE

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
                   value: {{ .Values.cronjob.environment.strict | quote }}
                 - name: ENVIRONMENT.SAPIGTYPE
                   value: {{ .Values.cronjob.environment.sapigType }}
-                - name: ENVIRONMENT.TYPE
+                - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:
                       name: core-deployment-config

--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -41,18 +41,7 @@ spec:
                     configMapKeyRef:
                       name: core-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
-                {{- if eq .Values.cronjob.environment.frPlatformType "FIDC" }}
-                - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: initializer-secret
-                      key: cdm-admin-password
-                - name: USERS.FR_PLATFORM_ADMIN_USERNAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: initializer-secret
-                      key: cdm-admin-user
-                {{- else }}
+                {{- if eq .Values.cronjob.environment.frPlatformType "CDK" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -20,7 +20,7 @@ spec:
               value: {{ .Values.job.environment.strict | quote }}
             - name: ENVIRONMENT.SAPIGTYPE
               value: {{ .Values.job.environment.sapigType }}
-            - name: ENVIRONMENT.TYPE
+            - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:
                   name: core-deployment-config

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -35,18 +35,7 @@ spec:
                 configMapKeyRef:
                   name: core-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
-            {{- if eq .Values.job.environment.frPlatformType "FIDC" }}
-            - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: initializer-secret
-                  key: cdm-admin-password
-            - name: USERS.FR_PLATFORM_ADMIN_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: initializer-secret
-                  key: cdm-admin-user
-            {{- else }}
+            {{- if eq .Values.job.environment.frPlatformType "CDK" }}
             - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -14,7 +14,7 @@ ENVIRONMENT: # Root key to define the environment program properties
   # CDK value: (Cloud Developer's Kit) development identity platform
   # CDM value: CDM (Cloud Deployment Model) identity cloud platform
   # FIDC (Forgerock Identity Cloud) identity cloud platform
-  TYPE: CDK
+  CLOUDTYPE: CDK
   NAMESPACE: dev # Root key to get the namespace/environment to populate the user data
   PATHS:
     CONFIG_AUTH_HELPER: config/defaults/auth-helper/  # Path for json to help with auth on FIdC platform

--- a/main.go
+++ b/main.go
@@ -50,18 +50,17 @@ var config types.Configuration
 
 func main() {
 	// operations
-	checkValidPlatformCert()
-	session := getIdentityPlatformSession()
-
-	fmt.Println("Resty initialization....")
-
-	//get IDM auth code
-	session.Authenticate()
-
-	//to obtain cookies values
-	httprest.InitRestReaderWriter(session.Cookie, session.AuthToken.AccessToken)
-	fmt.Println("Attempt to create PSU User..")
-	userId := rs.CreatePSU()
+	if common.Config.Environment.CloudType == "CDK" {
+		checkValidPlatformCert()
+		session := getIdentityPlatformSession()		
+		fmt.Println("Resty initialization....")		
+		//get IDM auth code
+		session.Authenticate()		
+		//to obtain cookies values
+		httprest.InitRestReaderWriter(session.Cookie, session.AuthToken.AccessToken)
+		fmt.Println("Attempt to create PSU User..")
+		userId := rs.CreatePSU()
+	}
 	if common.Config.Environment.SapigType == "ob" {
 		fmt.Println("Attempt to populate RS Data..")
 		rs.PopulateRSData(userId)

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -27,7 +27,7 @@ type identity struct {
 type environment struct {
 	Verbose   bool   `mapstructure:"VERBOSE"`
 	Strict    bool   `mapstructure:"STRICT"`
-	Type      string `mapstructure:"TYPE"`
+	CloudType string `mapstructure:"CLOUDTYPE"`
 	Paths     paths  `mapstructure:"PATHS"`
 	SapigType string `mapstructure:"SAPIGTYPE"`
 }


### PR DESCRIPTION
- Only check and create PSU4USER if the environment type is CDK and for FIDC instances, the fr_config_manager creates the user
- Update `TYPE` to be `CLOUD_TYPE` 
- Remove adding values from initializer-secret as this secret will be phased out when 2FA bypass is removed

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1337