### PR TITLE
754: Run initializer using Service Account

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
                   value: {{ .Values.cronjob.environment.strict | quote }}
                 - name: ENVIRONMENT.SAPIGTYPE
                   value: {{ .Values.cronjob.environment.sapigType }}
-                - name: ENVIRONMENT.CONFIGTYPE
+                - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:
                       name: core-deployment-config

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -20,7 +20,7 @@ spec:
               value: {{ .Values.job.environment.strict | quote }}
             - name: ENVIRONMENT.SAPIGTYPE
               value: {{ .Values.job.environment.sapigType }}
-            - name: ENVIRONMENT.CONFIGTYPE
+            - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:
                   name: core-deployment-config


### PR DESCRIPTION
Correct values in helm charts for setting cloudtype in test initialiser

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/754