### PR TITLE
1457: Use value in configmap for sapigtype env var

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -25,7 +25,10 @@ spec:
                 - name: ENVIRONMENT.STRICT
                   value: {{ .Values.cronjob.environment.strict | quote }}
                 - name: ENVIRONMENT.SAPIGTYPE
-                  value: {{ .Values.cronjob.environment.sapigType }}
+                  valueFrom:
+                    configMapKeyRef:
+                      name: core-deployment-config
+                      key: SAPIG_TYPE
                 - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -19,7 +19,10 @@ spec:
             - name: ENVIRONMENT.STRICT
               value: {{ .Values.job.environment.strict | quote }}
             - name: ENVIRONMENT.SAPIGTYPE
-              value: {{ .Values.job.environment.sapigType }}
+              valueFrom:
+                configMapKeyRef:
+                  name: core-deployment-config
+                  key: SAPIG_TYPE
             - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Use value in core-deployment-config configmap for sapigtype env var.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1457