### PR TITLE
1459: Cleanup use of sapigType in test init

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/values.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/values.yaml
@@ -2,10 +2,6 @@
 cronjob:
   environment:
     # Environment Settings for SAPIG & Cloud Platform
-    # SAPIG
-    # core: base sapig
-    # ob: Open Banking specification of sapig
-    sapigType: core
     # CDK value: (Cloud Developer's Kit) development identity platform
     # CDM value: CDM (Cloud Deployment Model) identity cloud platform
     # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
@@ -42,10 +38,6 @@ job:
   backoffLimit: 3
   environment:
     # Environment Settings for SAPIG & Cloud Platform
-    # SAPIG
-    # core: base sapig
-    # ob: Open Banking specification of sapig
-    sapigType: core
     # CDK value: (Cloud Developer's Kit) development identity platform
     # CDM value: CDM (Cloud Deployment Model) identity cloud platform
     # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform


### PR DESCRIPTION
Remove unused sapigType as value is coming from configmap

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1459