### PR TITLE
1533: Create cloud config for am-fahrenheit & use nightly-core env to test

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -44,6 +44,11 @@ spec:
                     configMapKeyRef:
                       name: core-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
+                - name: IDENTITY.AM_REALM
+                  valueFrom:
+                    configMapKeyRef:
+                      name: core-deployment-config
+                      key: AM_REALM
                 {{- if eq .Values.cronjob.environment.cloudType "FIDC" }}
                 - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY
                   valueFrom:

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -38,6 +38,11 @@ spec:
                 configMapKeyRef:
                   name: core-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
+            - name: IDENTITY.AM_REALM
+              valueFrom:
+                configMapKeyRef:
+                  name: core-deployment-config
+                  key: AM_REALM
             {{- if eq .Values.job.environment.cloudType "FIDC" }}
             - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY
               valueFrom:


### PR DESCRIPTION
AM_REALM was staying as alpha as not being overridden in helm templates

Not sure if this is an issue or not, but when the initialiser was calling to `am/json/realms/root/realms/alpha/users` the alpha part is always used where it may be bravo

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1533
