### PR TITLE
OPENIG-8961: Openig 8961: Separate ig instance deployments for authorisation server and resource server

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/readme.md
+++ b/_infra/helm/securebanking-test-data-initializer/readme.md
@@ -50,17 +50,17 @@ spec:
             - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: CLOUD_TYPE
             - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: HOSTS.IDENTITY_PLATFORM_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
               valueFrom:
@@ -117,17 +117,17 @@ spec:
                 - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: CLOUD_TYPE
                 - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: HOSTS.IDENTITY_PLATFORM_FQDN
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:
@@ -161,9 +161,9 @@ These are the environment variables declared in the `job.yaml` ;
 | Key | Default | Description | Source | Optional |
 |-----|---------|-------------|--------|----------|
 | ENVIRONMENT.STRICT | true | If true, any errors will cause the job to exit | cronjob.environment.strict |
-| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | core-deployment-config |
-| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
-| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
+| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | as-sapig-deployment-config |
+| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
+| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
 | USERS.FR_PLATFORM_ADMIN_PASSWORD | | Password for cloud instance. NOTE - This password can be used for `initializer-secret` or `am-env-secrets` depending on `ENVIRONMENT.CLOUDTYPE` set | If `ENVIRONMENT.CLOUDTYPE=FIDC` initializer-secret/cdm-admin-password else am-env-secrets/AM_PASSWORDS_AMADMIN_CLEAR |
 | USERS.FR_PLATFORM_ADMIN_USERNAME | | Username for cloud instance, only populated if `ENVIRONMENT.CLOUDTYPE=FIDC` | initializer-secret/cdm-admin-user |
 | NAMESPACE | dev | The namespace to install the object in | job.namespace |
@@ -172,9 +172,9 @@ These are the environment variables declared in the `cronjob.yaml` ;
 | Key | Default | Description | Source | Optional |
 |-----|---------|-------------|--------|----------|
 | ENVIRONMENT.STRICT | true | If true, any errors will cause the job to exit | cronjob.environment.strict |
-| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | core-deployment-config |
-| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
-| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
+| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | as-sapig-deployment-config |
+| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
+| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
 | USERS.FR_PLATFORM_ADMIN_PASSWORD | | Password for cloud instance. NOTE - This password can be used for `initializer-secret` or `am-env-secrets` depending on `ENVIRONMENT.CLOUDTYPE` set | If `ENVIRONMENT.CLOUDTYPE=FIDC` initializer-secret/cdm-admin-password else am-env-secrets/AM_PASSWORDS_AMADMIN_CLEAR |
 | USERS.FR_PLATFORM_ADMIN_USERNAME | | Username for cloud instance, only populated if `ENVIRONMENT.CLOUDTYPE=FIDC` | initializer-secret/cdm-admin-user |
 | NAMESPACE | dev | The namespace to install the object in | job.namespace |

--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -27,27 +27,27 @@ spec:
                 - name: ENVIRONMENT.SAPIGTYPE
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: SAPIG_TYPE
                 - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: CLOUD_TYPE
                 - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: HOSTS.IDENTITY_PLATFORM_FQDN
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: IDENTITY.AM_REALM
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: AM_REALM
                 {{- if eq .Values.cronjob.environment.cloudType "FIDC" }}
                 - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -21,27 +21,27 @@ spec:
             - name: ENVIRONMENT.SAPIGTYPE
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: SAPIG_TYPE
             - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: CLOUD_TYPE
             - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: HOSTS.IDENTITY_PLATFORM_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: IDENTITY.AM_REALM
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: AM_REALM
             {{- if eq .Values.job.environment.cloudType "FIDC" }}
             - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY


### PR DESCRIPTION
DO NOT MERGE - PR Created to create new Core Image

- Updated configmap and secrets for fapi-pep-as (may need changing when split for fapi-pep-rs happens)

Issue: https://pingidentity.atlassian.net/browse/OPENIG-8961