### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/readme.md
+++ b/_infra/helm/securebanking-test-data-initializer/readme.md
@@ -50,17 +50,17 @@ spec:
             - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: CLOUD_TYPE
             - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: HOSTS.IDENTITY_PLATFORM_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: as-sapig-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
               valueFrom:
@@ -117,17 +117,17 @@ spec:
                 - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: CLOUD_TYPE
                 - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: HOSTS.IDENTITY_PLATFORM_FQDN
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: as-sapig-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:
@@ -161,9 +161,9 @@ These are the environment variables declared in the `job.yaml` ;
 | Key | Default | Description | Source | Optional |
 |-----|---------|-------------|--------|----------|
 | ENVIRONMENT.STRICT | true | If true, any errors will cause the job to exit | cronjob.environment.strict |
-| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | core-deployment-config |
-| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
-| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
+| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | as-sapig-deployment-config |
+| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
+| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
 | USERS.FR_PLATFORM_ADMIN_PASSWORD | | Password for cloud instance. NOTE - This password can be used for `initializer-secret` or `am-env-secrets` depending on `ENVIRONMENT.CLOUDTYPE` set | If `ENVIRONMENT.CLOUDTYPE=FIDC` initializer-secret/cdm-admin-password else am-env-secrets/AM_PASSWORDS_AMADMIN_CLEAR |
 | USERS.FR_PLATFORM_ADMIN_USERNAME | | Username for cloud instance, only populated if `ENVIRONMENT.CLOUDTYPE=FIDC` | initializer-secret/cdm-admin-user |
 | NAMESPACE | dev | The namespace to install the object in | job.namespace |
@@ -172,9 +172,9 @@ These are the environment variables declared in the `cronjob.yaml` ;
 | Key | Default | Description | Source | Optional |
 |-----|---------|-------------|--------|----------|
 | ENVIRONMENT.STRICT | true | If true, any errors will cause the job to exit | cronjob.environment.strict |
-| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | core-deployment-config |
-| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
-| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
+| ENVIRONMENT.CLOUDTYPE | FIDC | Type of Cloud Instance being ran, depends on what environment you are running | as-sapig-deployment-config |
+| IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
+| HOSTS.IDENTITY_PLATFORM_FQDN | iam.forgerock.financial | Custom Domain created in Cloud Instance | as-sapig-deployment-config |
 | USERS.FR_PLATFORM_ADMIN_PASSWORD | | Password for cloud instance. NOTE - This password can be used for `initializer-secret` or `am-env-secrets` depending on `ENVIRONMENT.CLOUDTYPE` set | If `ENVIRONMENT.CLOUDTYPE=FIDC` initializer-secret/cdm-admin-password else am-env-secrets/AM_PASSWORDS_AMADMIN_CLEAR |
 | USERS.FR_PLATFORM_ADMIN_USERNAME | | Username for cloud instance, only populated if `ENVIRONMENT.CLOUDTYPE=FIDC` | initializer-secret/cdm-admin-user |
 | NAMESPACE | dev | The namespace to install the object in | job.namespace |

--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -24,31 +24,59 @@ spec:
               env:
                 - name: ENVIRONMENT.STRICT
                   value: {{ .Values.cronjob.environment.strict | quote }}
+                {{- if eq .Values.cronjob.environment.sapigType "ob" }}
                 - name: ENVIRONMENT.SAPIGTYPE
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: ob-deployment-config
                       key: SAPIG_TYPE
                 - name: ENVIRONMENT.CLOUDTYPE
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: ob-deployment-config
                       key: CLOUD_TYPE
                 - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: ob-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: HOSTS.IDENTITY_PLATFORM_FQDN
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: ob-deployment-config
                       key: IDENTITY_PLATFORM_FQDN
                 - name: IDENTITY.AM_REALM
                   valueFrom:
                     configMapKeyRef:
-                      name: core-deployment-config
+                      name: ob-deployment-config
                       key: AM_REALM
+                {{- else }}
+                - name: ENVIRONMENT.SAPIGTYPE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: as-sapig-deployment-config
+                      key: SAPIG_TYPE
+                - name: ENVIRONMENT.CLOUDTYPE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: as-sapig-deployment-config
+                      key: CLOUD_TYPE
+                - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
+                  valueFrom:
+                    configMapKeyRef:
+                      name: as-sapig-deployment-config
+                      key: IDENTITY_PLATFORM_FQDN
+                - name: HOSTS.IDENTITY_PLATFORM_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: as-sapig-deployment-config
+                      key: IDENTITY_PLATFORM_FQDN
+                - name: IDENTITY.AM_REALM
+                  valueFrom:
+                    configMapKeyRef:
+                      name: as-sapig-deployment-config
+                      key: AM_REALM
+                {{ end }}
                 {{- if eq .Values.cronjob.environment.cloudType "FIDC" }}
                 - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY
                   valueFrom:

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -18,31 +18,59 @@ spec:
           env:
             - name: ENVIRONMENT.STRICT
               value: {{ .Values.job.environment.strict | quote }}
+            {{- if eq .Values.job.environment.sapigType "ob" }}
             - name: ENVIRONMENT.SAPIGTYPE
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: ob-deployment-config
                   key: SAPIG_TYPE
             - name: ENVIRONMENT.CLOUDTYPE
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: ob-deployment-config
                   key: CLOUD_TYPE
             - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: ob-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: HOSTS.IDENTITY_PLATFORM_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: ob-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: IDENTITY.AM_REALM
               valueFrom:
                 configMapKeyRef:
-                  name: core-deployment-config
+                  name: ob-deployment-config
                   key: AM_REALM
+            {{- else }}
+            - name: ENVIRONMENT.SAPIGTYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: as-sapig-deployment-config
+                  key: SAPIG_TYPE
+            - name: ENVIRONMENT.CLOUDTYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: as-sapig-deployment-config
+                  key: CLOUD_TYPE
+            - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
+              valueFrom:
+                configMapKeyRef:
+                  name: as-sapig-deployment-config
+                  key: IDENTITY_PLATFORM_FQDN
+            - name: HOSTS.IDENTITY_PLATFORM_FQDN
+              valueFrom:
+                configMapKeyRef:
+                  name: as-sapig-deployment-config
+                  key: IDENTITY_PLATFORM_FQDN
+            - name: IDENTITY.AM_REALM
+              valueFrom:
+                configMapKeyRef:
+                  name: as-sapig-deployment-config
+                  key: AM_REALM
+            {{ end }}
             {{- if eq .Values.job.environment.cloudType "FIDC" }}
             - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY
               valueFrom:
@@ -59,8 +87,8 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: am-env-secrets
-                  key: AM_PASSWORDS_AMADMIN_CLEAR      
-            {{ end }}    
+                  key: AM_PASSWORDS_AMADMIN_CLEAR
+            {{ end }}
             - name: NAMESPACE
               value: {{ .Values.job.namespace }}
           command: [ "/bin/sh", "-c" ]

--- a/_infra/helm/securebanking-test-data-initializer/values.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/values.yaml
@@ -6,6 +6,7 @@ cronjob:
     # CDM value: CDM (Cloud Deployment Model) identity cloud platform
     # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
     cloudType: CDK
+    sapigType: core
     # RaiseForStatus will exit if go resty returns an error in STRICT mode,
     # be it client error, server error or other. Turning off (false)
     # STRICT mode will simply warn of client/server errors.
@@ -42,6 +43,7 @@ job:
     # CDM value: CDM (Cloud Deployment Model) identity cloud platform
     # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
     cloudType: CDK
+    sapigType: core
     # RaiseForStatus will exit if go resty returns an error in STRICT mode,
     # be it client error, server error or other. Turning off (false)
     # STRICT mode will simply warn of client/server errors.


### PR DESCRIPTION
Update config for new IG AS / RS split, use old configmaps if the sapig type is OB

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676