### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/cronjob.yaml
@@ -24,33 +24,6 @@ spec:
               env:
                 - name: ENVIRONMENT.STRICT
                   value: {{ .Values.cronjob.environment.strict | quote }}
-                {{- if eq .Values.cronjob.environment.sapigType "ob" }}
-                - name: ENVIRONMENT.SAPIGTYPE
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ob-deployment-config
-                      key: SAPIG_TYPE
-                - name: ENVIRONMENT.CLOUDTYPE
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ob-deployment-config
-                      key: CLOUD_TYPE
-                - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ob-deployment-config
-                      key: IDENTITY_PLATFORM_FQDN
-                - name: HOSTS.IDENTITY_PLATFORM_FQDN
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ob-deployment-config
-                      key: IDENTITY_PLATFORM_FQDN
-                - name: IDENTITY.AM_REALM
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ob-deployment-config
-                      key: AM_REALM
-                {{- else }}
                 - name: ENVIRONMENT.SAPIGTYPE
                   valueFrom:
                     configMapKeyRef:
@@ -76,7 +49,6 @@ spec:
                     configMapKeyRef:
                       name: as-sapig-deployment-config
                       key: AM_REALM
-                {{ end }}
                 {{- if eq .Values.cronjob.environment.cloudType "FIDC" }}
                 - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY
                   valueFrom:

--- a/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
+++ b/_infra/helm/securebanking-test-data-initializer/templates/job.yaml
@@ -18,33 +18,6 @@ spec:
           env:
             - name: ENVIRONMENT.STRICT
               value: {{ .Values.job.environment.strict | quote }}
-            {{- if eq .Values.job.environment.sapigType "ob" }}
-            - name: ENVIRONMENT.SAPIGTYPE
-              valueFrom:
-                configMapKeyRef:
-                  name: ob-deployment-config
-                  key: SAPIG_TYPE
-            - name: ENVIRONMENT.CLOUDTYPE
-              valueFrom:
-                configMapKeyRef:
-                  name: ob-deployment-config
-                  key: CLOUD_TYPE
-            - name: IDENTITY_PLATFORM_FQDN # variable to run the command shell, the shell doesn't support variables with dot.
-              valueFrom:
-                configMapKeyRef:
-                  name: ob-deployment-config
-                  key: IDENTITY_PLATFORM_FQDN
-            - name: HOSTS.IDENTITY_PLATFORM_FQDN
-              valueFrom:
-                configMapKeyRef:
-                  name: ob-deployment-config
-                  key: IDENTITY_PLATFORM_FQDN
-            - name: IDENTITY.AM_REALM
-              valueFrom:
-                configMapKeyRef:
-                  name: ob-deployment-config
-                  key: AM_REALM
-            {{- else }}
             - name: ENVIRONMENT.SAPIGTYPE
               valueFrom:
                 configMapKeyRef:
@@ -70,7 +43,6 @@ spec:
                 configMapKeyRef:
                   name: as-sapig-deployment-config
                   key: AM_REALM
-            {{ end }}
             {{- if eq .Values.job.environment.cloudType "FIDC" }}
             - name: USERS.FIDC_PLATFORM_SERVICE_ACCOUNT_KEY
               valueFrom:


### PR DESCRIPTION
Rename ob-deployment-config & ob-secrets to rs-sapig

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676